### PR TITLE
added POST, PUT, DELETE routes to modify Service objects through API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Please send an email to security-notification@ga4gh.org.
 
 General-purpose service registries you might know from microservices (like [Eureka](https://github.com/Netflix/eureka) or [Consul](https://www.hashicorp.com/products/consul/service-discovery)) are designed to allow services to programmatically discover other services in their environment. They work within organizational boundaries and rely on the environment being under your control. They use custom proprietary APIs and are fairly heavy-weight (provide a lot of additional functionality like rich health checking, multi-datacenter awareness, service management).
 
-This service registry is a minimalistic, light-weight, read-only, standard API. It's designed to aggregate services from many organizations across organizational boundaries, without imposing communication restrictions on these services, or even requiring them to be aware of the registry they're a part of. Rather than internal service-service discovery, this registry is often used to advertise services to arbitrary clients outside of the service organization. The registry is GA4GH-aware and supports metadata specific to GA4GH web services.
+This service registry is a minimalistic, light-weight, standard API. It's designed to aggregate services from many organizations across organizational boundaries, without imposing communication restrictions on these services, or even requiring them to be aware of the registry they're a part of. Rather than internal service-service discovery, this registry is often used to advertise services to arbitrary clients outside of the service organization. The registry is GA4GH-aware and supports metadata specific to GA4GH web services.
 
 ### Does the registry support non-GA4GH services?
 

--- a/service-registry.yaml
+++ b/service-registry.yaml
@@ -37,6 +37,30 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         default:
           $ref: '#/components/responses/Error'
+    post:
+      summary: Create new service in the registry
+      operationId: createService
+      tags:
+        - services
+      requestBody:
+        $ref: '#/components/requestBodies/Service'
+      responses:
+        200:
+          description: Created new service
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalService'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          $ref: '#/components/responses/Error'
   /services/{serviceId}:
     get:
       summary: 'Find service in the registry by ID'
@@ -44,12 +68,7 @@ paths:
       tags:
         - services
       parameters:
-        - name: serviceId
-          in: path
-          description: 'ID of the service to find'
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/ServiceId'
       responses:
         '200':
           description: 'Information about a service with the given ID'
@@ -64,6 +83,50 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update the existing service with the given ID
+      operationId: updateServiceById
+      tags:
+        - services
+      parameters:
+        - $ref: '#/components/parameters/ServiceId'
+      requestBody:
+        $ref: '#/components/requestBodies/Service'
+      responses:
+        200:
+          description: Updated the service with new properties
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalService'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          $ref: '#/components/responses/Error'
+    delete:
+      summary: Delete the service with the given ID
+      operationId: deleteServiceById
+      tags:
+        - services
+      parameters:
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        200:
+          description: Service was deleted
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        500:
           $ref: '#/components/responses/InternalServerError'
         default:
           $ref: '#/components/responses/Error'
@@ -121,7 +184,29 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  parameters:
+    ServiceId:
+      name: serviceId
+      in: path
+      description: 'ID of the service to find'
+      required: true
+      schema:
+        type: string
+  requestBodies:
+    Service:
+      description: Service to create or update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ExternalService'
   responses:
+    BadRequest:
+      description: 'Bad Request ([RFC 7231, section 6.5.1](https://tools.ietf.org/html/rfc7231#section-6.5.1))'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
     Unauthorized:
       description: 'Unauthorized ([RFC 7235](https://tools.ietf.org/html/rfc7235))'
       content:

--- a/service-registry.yaml
+++ b/service-registry.yaml
@@ -1,10 +1,16 @@
 openapi: 3.0.2
 info:
   title: 'GA4GH Service Registry API Specification'
-  version: 1.0.0
+  version: 1.1.0
   description: |
     Service registry is a GA4GH service providing information about other GA4GH services, primarily for the purpose of organizing services into networks or groups and service discovery across organizational boundaries. Information about the individual services in the registry is described in a complementary [service-info](https://github.com/ga4gh-discovery/ga4gh-service-info) specification.
     More information on [GitHub](https://github.com/ga4gh-discovery/ga4gh-service-registry/).
+
+    ## Write endpoints
+
+    With the service registry version `1.0.0` release, additional endpoints have been added.
+    `POST`, `PUT`, and `DELETE` endpoints allows clients to add, modify, and delete services within the registry, respectively.
+    These endpoints are **OPTIONAL**, registries can leave them unimplemented and still remain conformant to the specification.
   license:
     name: 'Apache 2.0'
     url: 'https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-registry/develop/LICENSE'


### PR DESCRIPTION
PR for #65 

- Added `POST` operation to `/services` 
- Added `PUT` and `DELETE` operations to `/services/{serviceId}`
- a common `requestBody` is submitted to `POST` or `PUT` operations to create or update a service, respectively

Some questions for the group:
- should we also include a `PATCH` operation for simple modification of a few properties?
- should we add additional auth scopes to differentiate between `read` and `write` of objects?

@mcupak @jrambla 
