### PR TITLE
Feature/use gh openapi docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ Session.vim
 
 #********** IntelliJ files ******
 *.iml
+
+#********** Custom files ******
+
+!.spec-docs.json

--- a/.spec-docs.json
+++ b/.spec-docs.json
@@ -1,0 +1,6 @@
+{
+  "apiSpecPath": "service-registry.yaml",
+  "docsRoot": "docs",
+  "defaultBranch": "master",
+  "branchPathBase": "preview"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
+git:
+  depth: false
 language: java
 dist: bionic
 sudo: false
 jdk:
   - openjdk11
 env:
-  - GH_URL=https://raw.githubusercontent.com FILE_TO_VALIDATE=service-registry.yaml URL_TO_VALIDATE=$GH_URL/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/$FILE_TO_VALIDATE
+  global:
+    - GH_URL=https://raw.githubusercontent.com
+    - FILE_TO_VALIDATE=service-registry.yaml
+    - URL_TO_VALIDATE=$GH_URL/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/$FILE_TO_VALIDATE
+    - GH_PAGES_NAME='ga4gh-bot'
+    - GH_PAGES_EMAIL='ga4ghdev@gmail.com'
+    - secure: eLCsVSQgaq2yi/c2Wz5atKRenRwbVZhw9WpMH8F3vdGgcHFbw6uZ+UgERTI8mCkB+CmvnJ/2QOwidE4cIVYIvt1Z0wF4Gv71yVoV1P4FJPtbZKXqcOcn9BTvAjRkkvkfTFbs9eZuDjcNp7hwJBFcMy+ZBsBHERJC26klrhmpwP5kF0dccTNQQfd6wzRcBGMHxBW32P0ONWiRI0ROBnqt94UEcM5OD6cRXnZcev539JhTeSy1hKINHUj96m5vvG1wtD/Ti7MYY9jia3RLN+JOxTtCGJ4wbuFdWobpa+X3RAZn4WOIrFsyobcZXc9Kr/PAz39hoYqJuiS2HIzVxpnsw4kmkYubjSCKhXwe5IBtrhMOiuwzsyIpSYN1shDSZmpE6G3jptuEPtznNWyA1dGyWRHR2NZRFAm67SLLsN7mEfOwHQrbBUMMmetEF/aG5DeupIe9YHXmpE16ijfRx67ftYnDpkRtcJSToy+98qQFd1w3SfX++TtTX69+lBJKUHqzAdbAGqcWd0X7EB7NhMVIP4rjORczBz2OGqPwCmlC/eYS7Fw54F1WwshoBNufERpdSGPzsKKMNWy7UvQaTdXpN/HGJnX/xURKZeiJPoly6tTzZlCSbsBpUDWyKMkmtTqFsgQR/lZ+x/lHmcDMHy6p8k1gNY5zoZhZb71llPN+18I=
 before_install:
   - git clone --branch=v1.1.0 https://github.com/mcupak/oas-validator.git
 script:
   - ./oas-validator/validate.sh "$URL_TO_VALIDATE"
+after_success:
+  - chmod 755 ./scripts/push-openapi-docs.sh
+  - "./scripts/push-openapi-docs.sh"

--- a/scripts/push-openapi-docs.sh
+++ b/scripts/push-openapi-docs.sh
@@ -1,0 +1,86 @@
+# push-openapi-docs.sh
+# on travis ci, run the gh-openapi-docs tool and push built documentation to gh-pages branch
+
+# install node version manager (nvm), which will install the correct nodejs version
+function install_nvm {
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+    nvm --version
+}
+
+# install correct nodejs version via nvm
+function install_node {
+    NODE_VERSION="12.18.3"
+    nvm install ${NODE_VERSION}
+    nvm use ${NODE_VERSION}
+    node -v
+}
+
+# install the gh-openapi-docs tool from npm
+function install_gh_openapi_docs {
+    npm install -g @redocly/openapi-cli && npm install -g redoc-cli
+    npm install -g @ga4gh/gh-openapi-docs
+}
+
+# configure the github account that will push to the gh-pages branch of this repo
+function setup_github_bot {
+    git config user.name $GH_PAGES_NAME
+    git config user.email $GH_PAGES_EMAIL
+    git config credential.helper "store --file=.git/credentials"
+    echo "https://${GH_PAGES_TOKEN}:x-oauth-basic@github.com" > .git/credentials
+}
+
+# remove credentials of github account from build
+function cleanup_github_bot {
+  rm .git/credentials
+}
+
+# pulls the remote gh-pages branch to local
+function setup_github_branch {
+    git checkout -b gh-pages
+    git branch --set-upstream-to=origin/gh-pages
+    git config pull.rebase false
+    git add preview
+    git add docs
+    git add openapi.json
+    git add openapi.yaml
+    git stash save
+    git pull
+    git checkout stash -- .
+}
+
+# commit the outputs from gh-openapi-docs
+function commit_gh_openapi_docs_outputs {
+    git commit -m "added docs from gh-openapi-docs"
+}
+
+# main method
+function main {
+    if [[ $TRAVIS_BRANCH == master || $TRAVIS_BRANCH == develop || $TRAVIS_BRANCH == release* ]]; then
+        echo -e "travis branch: ${TRAVIS_BRANCH}; building documentation"
+        echo -e "installing nvm"
+        install_nvm
+        echo -e "installing nodejs"
+        install_node
+        echo -e "installing gh-openapi-docs"
+        install_gh_openapi_docs
+        echo -e "running gh-openapi-docs"
+        gh-openapi-docs
+        echo -e "configuring github account to push to gh-pages branch"
+        setup_github_bot
+        echo -e "pulling gh-pages to local and merging local changes"
+        setup_github_branch
+        commit_gh_openapi_docs_outputs
+        echo -e "pushing to remote gh-pages branch"
+        git push
+        echo -e "cleaning up"
+        cleanup_github_bot
+    else
+        echo -e "travis branch: ${TRAVIS BRANCH}; not building documentation"
+    fi
+}
+
+main
+exit 0

--- a/scripts/push-openapi-docs.sh
+++ b/scripts/push-openapi-docs.sh
@@ -78,7 +78,7 @@ function main {
         echo -e "cleaning up"
         cleanup_github_bot
     else
-        echo -e "travis branch: ${TRAVIS BRANCH}; not building documentation"
+        echo -e "travis branch: ${TRAVIS_BRANCH}; not building documentation"
     fi
 }
 


### PR DESCRIPTION
The Cloud WS has developed [gh-openapi-docs](https://www.npmjs.com/package/gh-openapi-docs), a tool that generates standalone documentation pages from OpenAPI specs. This PR adds a new script that builds docs for any pushes to `develop`, `master`, or `release/*`, and pushes the docs to the `gh-pages` branch. This will be especially useful for keeping historical versions of the `service-registry` spec available once we make the jump to 1.1 and beyond.

I've built some docs on my fork for different versions, which end up living at non-clashing URLs. See:
- https://jb-adams.github.io/ga4gh-service-registry/preview/release/0.1.0/docs/
- https://jb-adams.github.io/ga4gh-service-registry/preview/release/1.0.0/docs/

Cloud WS is using a tool like this for [DRS](https://github.com/ga4gh/data-repository-service-schemas) and possibly it's other specs. See the "API Definition" table where older versions are available

@jaeddy @mcupak 